### PR TITLE
feat: Adding more projects endpoints

### DIFF
--- a/sonarqube/rest/projects.py
+++ b/sonarqube/rest/projects.py
@@ -4,6 +4,9 @@
 from sonarqube.utils.rest_client import RestClient
 from sonarqube.utils.config import (
     API_PROJECTS_SEARCH_ENDPOINT,
+    API_PROJECTS_CREATE_PROJECT_ENDPOINT,
+    API_PROJECTS_BULK_DELETE_ENDPOINT,
+    API_PROJECTS_DELETE_ENDPOINT,
 )
 from sonarqube.utils.common import GET, POST
 
@@ -65,5 +68,51 @@ class SonarQubeProjects(RestClient):
             * APP
           default value is TRK.
 
+        :return:
+        """
+
+    @POST(API_PROJECTS_CREATE_PROJECT_ENDPOINT)
+    def create_project(self, name=None, project=None, visibility=None):
+        """
+        SINCE 4.0
+        Create a project. Requires 'Create Projects' permission.
+        :param: name: required. Name of the project. If name is longer than 500, it is abbreviated.
+        :param project: required. Key of the project
+        :param visibility: Whether the created project should be visible to everyone, or only specific user/groups.
+          If no visibility is specified, the default project visibility of the organization will be used.
+          Possible values
+            * private
+            * public
+        """
+
+    @POST(API_PROJECTS_DELETE_ENDPOINT)
+    def delete_project(self, key):
+        """
+        SINCE 5.2
+        Delete a project
+        :param key: Project key
+        :return:
+        """
+
+    @POST(API_PROJECTS_BULK_DELETE_ENDPOINT)
+    def bulk_delete_project(
+        self,
+        analyzedBefore=None,
+        onProvisionedOnly=False,
+        projects=None,
+        q=None,
+        qualifiers=None,
+    ):
+        """
+        SINCE 5.2
+        Delete one or several projects.
+        :param analyzedBefore: Filter the projects for which last analysis of any branch is older than the given date (exclusive).
+                               Either a date (server timezone) or datetime can be provided.
+        :param onProvisionedOnly: Filter the projects that are provisioned
+        :param projects: Comma-separated list of project keys
+        :param q: Limit to:
+                    component names that contain the supplied string
+                    component keys that contain the supplied string
+        :param qualifiers: Comma-separated list of component qualifiers. Filter the results with the specified qualifiers
         :return:
         """

--- a/sonarqube/utils/config.py
+++ b/sonarqube/utils/config.py
@@ -1,6 +1,9 @@
 API_COMPONENTS_SHOW_ENDPOINT = "/api/components/show"
 
 API_PROJECTS_SEARCH_ENDPOINT = "/api/projects/search"
+API_PROJECTS_CREATE_PROJECT_ENDPOINT = "/api/projects/create"
+API_PROJECTS_BULK_DELETE_ENDPOINT = "/api/projects/bulk_delete"
+API_PROJECTS_DELETE_ENDPOINT = "/api/projects/delete"
 
 API_USERS_SEARCH_ENDPOINT = "/api/users/search"
 API_USER_GROUPS_SEARCH_ENDPOINT = "/api/user_groups/search"


### PR DESCRIPTION
This commit uses the code from two different PRs to add support for creating and deleting projects.

Two new endpoints are added to projects.py

See:

https://github.com/shijl0925/python-sonarqube-api/pull/95 https://github.com/shijl0925/python-sonarqube-api/pull/97