### PR TITLE
fix: changing param in delete

### DIFF
--- a/sonarqube/rest/projects.py
+++ b/sonarqube/rest/projects.py
@@ -86,11 +86,11 @@ class SonarQubeProjects(RestClient):
         """
 
     @POST(API_PROJECTS_DELETE_ENDPOINT)
-    def delete_project(self, key):
+    def delete_project(self, project):
         """
         SINCE 5.2
         Delete a project
-        :param key: Project key
+        :param project: Project key
         :return:
         """
 


### PR DESCRIPTION
This command changes the parameter name in the delete call. The sonar API is expecting project and not key.